### PR TITLE
Fix runtime type introspection for datastar_response decorator

### DIFF
--- a/src/datastar_py/litestar.py
+++ b/src/datastar_py/litestar.py
@@ -77,7 +77,7 @@ def datastar_response(
             return DatastarResponse(await r)
         return DatastarResponse(r)
 
-    wrapper.__annotations__["return"] = "DatastarResponse"
+    wrapper.__annotations__["return"] = DatastarResponse
     return wrapper
 
 

--- a/src/datastar_py/quart.py
+++ b/src/datastar_py/quart.py
@@ -55,7 +55,7 @@ def datastar_response(
             return DatastarResponse(stream_with_context(func)(*args, **kwargs))
         return DatastarResponse(await copy_current_request_context(func)(*args, **kwargs))
 
-    wrapper.__annotations__["return"] = "DatastarResponse"
+    wrapper.__annotations__["return"] = DatastarResponse
     return wrapper
 
 

--- a/src/datastar_py/sanic.py
+++ b/src/datastar_py/sanic.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Collection, Mapping
 from functools import wraps
 from inspect import isasyncgen, isgenerator
-from typing import Any, Callable, ParamSpec
+from typing import Any, Callable, ParamSpec, Union
 
 from sanic import HTTPResponse, Request
 
@@ -87,7 +87,7 @@ def datastar_response(
             return None
         return DatastarResponse(r)
 
-    wrapper.__annotations__["return"] = "DatastarResponse"
+    wrapper.__annotations__["return"] = Union[DatastarResponse, None]
     return wrapper
 
 

--- a/src/datastar_py/starlette.py
+++ b/src/datastar_py/starlette.py
@@ -67,7 +67,7 @@ def datastar_response(
             return DatastarResponse(await r)
         return DatastarResponse(r)
 
-    wrapper.__annotations__["return"] = "DatastarResponse"
+    wrapper.__annotations__["return"] = DatastarResponse
     return wrapper
 
 


### PR DESCRIPTION
sanic-ext was causing a crash when `datastar_response` was used when it tried to introspect the annotations.
```NameError: name 'DatastarResponse' is not defined. Did you mean: 'datastar_response'?```
This should fix that issue.