### PR TITLE
Slightly opinionated wait time formatting

### DIFF
--- a/src/datastar_py/attributes.py
+++ b/src/datastar_py/attributes.py
@@ -433,6 +433,19 @@ class TimingMod:
         return self
 
 
+class DelayMod:
+    def delay(
+        self: Self,
+        wait: int | float | str,
+    ) -> Self:
+        """Delay the event listener.
+
+        :param wait: The minimum interval between events.
+        """
+        self._mods["delay"] = [str(wait)]
+        return self
+
+
 class ViewtransitionMod:
     @property
     def viewtransition(self: Self) -> Self:
@@ -461,7 +474,7 @@ class IgnoreAttr(BaseAttr):
         return self
 
 
-class OnAttr(BaseAttr, TimingMod, ViewtransitionMod):
+class OnAttr(BaseAttr, TimingMod, DelayMod, ViewtransitionMod):
     _attr = "on"
 
     @property
@@ -628,7 +641,7 @@ class ScrollIntoViewAttr(BaseAttr):
         return self
 
 
-class OnIntersectAttr(BaseAttr, TimingMod, ViewtransitionMod):
+class OnIntersectAttr(BaseAttr, TimingMod, DelayMod, ViewtransitionMod):
     @property
     def once(self) -> Self:
         """Only trigger the event listener once."""
@@ -659,13 +672,8 @@ class OnIntervalAttr(BaseAttr, ViewtransitionMod):
         return self
 
 
-class OnLoadAttr(BaseAttr, ViewtransitionMod):
+class OnLoadAttr(BaseAttr, ViewtransitionMod, DelayMod):
     _attr = "on-load"
-
-    def delay(self, delay: int | float | str) -> Self:
-        """Delay the event listener."""
-        self._mods["delay"] = [str(delay)]
-        return self
 
     @property
     def once(self) -> Self:
@@ -678,7 +686,7 @@ class OnRafAttr(BaseAttr, TimingMod):
     _attr = "on-raf"
 
 
-class OnSignalPatchAttr(BaseAttr, TimingMod):
+class OnSignalPatchAttr(BaseAttr, TimingMod, DelayMod):
     _attr = "on-signal-patch"
 
     def filter(self, include: str | None = None, exclude: str | None = None) -> Self:

--- a/src/datastar_py/attributes.py
+++ b/src/datastar_py/attributes.py
@@ -111,6 +111,9 @@ SignalValue: TypeAlias = Union[
 ]
 
 
+WaitTime: TypeAlias = Union[int, float, str]
+
+
 class AttributeGenerator:
     def __init__(self, alias: str = "data-") -> None:
         """A helper which can generate all the Datastar attributes.
@@ -390,7 +393,7 @@ class BaseAttr(Mapping):
 class TimingMod:
     def debounce(
         self: Self,
-        wait: int | float | str,
+        wait: WaitTime,
         *,
         leading: bool = False,
         notrail: bool = False,
@@ -403,7 +406,7 @@ class TimingMod:
         :param notrail: If True, the event listener will not be called on the trailing edge of the
             wait time.
         """
-        self._mods["debounce"] = [str(wait)]
+        self._mods["debounce"] = [_format_wait_time(wait)]
         if leading:
             self._mods["debounce"].append("leading")
         if notrail:
@@ -412,7 +415,7 @@ class TimingMod:
 
     def throttle(
         self: Self,
-        wait: int | float | str,
+        wait: WaitTime,
         *,
         noleading: bool = False,
         trail: bool = False,
@@ -425,7 +428,7 @@ class TimingMod:
         :param trail: If true, the event listener will be called on the trailing edge of the
             wait time.
         """
-        self._mods["throttle"] = [str(wait)]
+        self._mods["throttle"] = [_format_wait_time(wait)]
         if noleading:
             self._mods["throttle"].append("noleading")
         if trail:
@@ -436,13 +439,13 @@ class TimingMod:
 class DelayMod:
     def delay(
         self: Self,
-        wait: int | float | str,
+        wait: WaitTime,
     ) -> Self:
         """Delay the event listener.
 
         :param wait: The minimum interval between events.
         """
-        self._mods["delay"] = [str(wait)]
+        self._mods["delay"] = [_format_wait_time(wait)]
         return self
 
 
@@ -664,9 +667,9 @@ class OnIntersectAttr(BaseAttr, TimingMod, DelayMod, ViewtransitionMod):
 class OnIntervalAttr(BaseAttr, ViewtransitionMod):
     _attr = "on-interval"
 
-    def duration(self, duration: int | float | str, *, leading: bool = False) -> Self:
+    def duration(self, duration: WaitTime, *, leading: bool = False) -> Self:
         """Set the interval duration."""
-        self._mods["duration"] = [str(duration)]
+        self._mods["duration"] = [_format_wait_time(duration)]
         if leading:
             self._mods["duration"].append("leading")
         return self
@@ -745,6 +748,34 @@ def _js_object(obj: dict) -> str:
             for k, v in obj.items()
         )
         + "}"
+    )
+
+
+def _format_wait_time(wait: WaitTime) -> str:
+    if isinstance(wait, int):
+        return f"{wait}ms"
+    
+    if isinstance(wait, float):
+        return f"{int(wait * 1000)}ms"
+    
+    if isinstance(wait, str):
+        s = wait.strip().lower()
+        if s.endswith("ms"):
+            num, unit = s[:-2], "ms"
+        elif s.endswith("s"):
+            num, unit = s[:-1], "s"
+        else:
+            num, unit = s, "ms"
+
+        if num.isdigit():
+            return f"{num}{unit}"
+
+        raise ValueError(
+            f"Invalid wait time: {wait!r}, expected format: {{int}}ms, {{int}}s, or {{int}}"
+        )
+    
+    raise ValueError(
+        f"Invalid wait time: {wait!r}, expected int, float, or str in format {{int}}ms, {{int}}s, or {{int}}"
     )
 
 


### PR DESCRIPTION
Here I'm just adding a little bit of structure to how we interpret wait times.
Basically the idea is the following:
- `int -> {int}ms`. 
   - `1000 -> 1000ms`
- `float -> {int(float*1000)ms` 
   - `1.5 -> 1500ms`
- `str -> ensure obeys spec format `
   - `"30s" - ok`
   - `"3.2ms" - fails`
