### PR TITLE
Set the version of python to the MSV in the CI workflow

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -11,4 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,16 +1,10 @@
 name: pre-commit
 
-on:
-  pull_request:
-  push:
-    branches: [main]
+on: [pull_request]
 
 jobs:
-  pre-commit:
+  prek:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-      - uses: pre-commit/action@v3.0.1
+      - uses: actions/checkout@v5
+      - uses: j178/prek-action@v1

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,9 +1,11 @@
 name: pre-commit
 
-on: [pull_request]
-
+on:
+  pull_request:
+  push:
+    branches: [main]
 jobs:
-  prek:
+  pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
During the CI run, I noticed a warning indicating we didn't set the python version in our workflow. I believe we shouldn't rely on the one on the worker PATH. 