### PR TITLE
fasthtml: use attribute generators in examples

### DIFF
--- a/examples/fasthtml/advanced.py
+++ b/examples/fasthtml/advanced.py
@@ -22,6 +22,7 @@ from fasthtml.common import *
 from great_tables import GT
 from great_tables.data import reactions
 
+from datastar_py import attribute_generator as data
 from datastar_py.fasthtml import DatastarResponse, ServerSentEventGenerator
 
 ######################################################################################################
@@ -42,7 +43,7 @@ from datastar_py.fasthtml import DatastarResponse, ServerSentEventGenerator
 app, rt = fast_app(
     htmx=False,
     surreal=False,
-    live=True,
+    live=False,
     hdrs=(
         Script(
             type="module",
@@ -133,14 +134,12 @@ def index():
                     ),
                 ),
                 # When the below request is in flight, $filtering becomes true, setting the aria-busy attribute
-                Label({"data-attr:aria-busy": "$filtering"}, fr="filter")("Filter Compound"),
+                Label(data.attr({"aria-busy": "$filtering"}), fr="filter")("Filter Compound"),
                 # Bind the 'filter' signal to the value of this input, debouncing using Datastar modifier
                 Input(
-                    {
-                        "data-on:input__debounce.250ms": f"@post('{table}')",
-                        "data-bind:filter": True,
-                        "data-indicator:filtering": True,
-                    },
+                    data.on("input", f"@post('{table}')").debounce("250ms"),
+                    data.bind("filter"),
+                    data.indicator("filtering"),
                     id="filter",
                     name="filter",
                 ),
@@ -177,12 +176,11 @@ async def hello():
 async def reset():
     reset_and_hello = Div(id="myElement")(
         Button(
-            {
-                "data-on:click": f"@get('{hello}')",
-                "data-indicator:resetting": True,
-                "data-attr:aria-busy": "$resetting",
-                "data-attr:disabled": "$resetting",
-            },
+            # Attributes can either be defined using the Datastar SDK's
+            # attribute_generator or with dicts as in HELLO_BUTTON below
+            data.on("click", f"@get('{hello}')"),
+            data.indicator("resetting"),
+            data.attr({"aria-busy": "$resetting", "disabled": "$resetting"}),
             type="reset",
         )("Reset"),
         Div("Hello!"),
@@ -200,8 +198,8 @@ HELLO_BUTTON = Div(id="myElement")(
     Button(
         {
             "data-on:click": f"@get('{reset}')",
-            "data-indicator:loading": True,
-            "data-attr:aria-busy": "$loading",
+            "data-indicator": "loading",
+            "data-attr:aria-loading": "$loading",
             "data-attr:disabled": "$loading",
         }
     )("Say hello"),

--- a/examples/fasthtml/advanced.py
+++ b/examples/fasthtml/advanced.py
@@ -199,7 +199,7 @@ HELLO_BUTTON = Div(id="myElement")(
         {
             "data-on:click": f"@get('{reset}')",
             "data-indicator": "loading",
-            "data-attr:aria-loading": "$loading",
+            "data-attr:aria-busy": "$loading",
             "data-attr:disabled": "$loading",
         }
     )("Say hello"),

--- a/examples/fasthtml/simple.py
+++ b/examples/fasthtml/simple.py
@@ -8,18 +8,18 @@
 # datastar-py = { path = "../../" }
 # ///
 import asyncio
-import json
 from datetime import datetime
 
 # ruff: noqa: F403, F405
 from fasthtml.common import *
 
+from datastar_py import attribute_generator as data
 from datastar_py.fasthtml import DatastarResponse, ServerSentEventGenerator, read_signals
 
 app, rt = fast_app(
     htmx=False,
     surreal=False,
-    live=True,
+    live=False,
     hdrs=(
         Script(
             type="module",
@@ -39,15 +39,15 @@ async def index():
     return Titled(
         "Datastar FastHTML example",
         example_style,
-        Body(data_signals=json.dumps({"currentTime": now}))(
+        Body(data.signals({"currentTime": now}))(
             Div(cls="container")(
-                Div(data_init="@get('/updates')", cls="time")(
+                Div(data.init("@get('/updates')"), cls="time")(
                     "Current time from element: ",
                     Span(id="currentTime")(now),
                 ),
                 Div(cls="time")(
                     "Current time from signal: ",
-                    Span(data_text="$currentTime")(now),
+                    Span(data.text("$currentTime"))(now),
                 ),
             ),
         ),


### PR DESCRIPTION
Also disabled `live=True` in the FastHTML app creation since it was causing some issue with the reload method (websocket) constantly reloading the page. Not sure what the issue is, but it's not a datastar issue. It might be better to just provide an example of Delaney's hotreload method. Here's a rough draft of it using the python SDK:

For it to work correctly:
```sh
uvicorn main:app --reload --timeout-graceful-shutdown 0
```

```python
import asyncio
from starlette.applications import Starlette
from starlette.responses import HTMLResponse
from starlette.requests import Request
from starlette.routing import Route

from datastar_py import ServerSentEventGenerator as SSE
from datastar_py import attribute_generator as data
from datastar_py.starlette import datastar_response


hot_reload_sent = False
hot_reload_lock = asyncio.Lock()


async def index(request: Request):
    return HTMLResponse(
        f"""
        <html>
            <head>
                <script type="module"
                    src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.0-RC.7/bundles/datastar.js">
                </script>
            </head>
            <body>
                <div>Hello world!</div>
                <div id="hotreload"
                     {data.init("@get('/hotreload', {retryMaxCount: 1000, retryInterval: 20, retryMaxWaitMs: 200})")}>
                </div>
            </body>
        </html>
        """
    )


@datastar_response
async def hotreload(request: Request):
    global hot_reload_sent

    async with hot_reload_lock:
        if not hot_reload_sent:
            hot_reload_sent = True
            yield SSE.execute_script("window.location.reload()")

    while not await request.is_disconnected():
        await asyncio.sleep(0.5)


app = Starlette(
    routes=[
        Route("/", index),
        Route("/hotreload", hotreload),
    ]
)
```