### PR TITLE
Keep GitHub Actions up to date with GitHub's Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep GitHub Actions up to date with GitHub's Dependabot...
+# https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot
+# https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    groups:
+      github-actions:
+        patterns:
+          - "*"  # Group all Actions updates into a single larger pull request
+    schedule:
+      interval: weekly


### PR DESCRIPTION
* [Keeping your software supply chain secure with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain)
* [Keeping your actions up to date with Dependabot](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot)
* [Configuration options for the `dependabot.yml` file - package-ecosystem](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-)

To see all GitHub Actions dependencies, type:
% `git grep 'uses: ' .github/workflows/`
```
.github/workflows/pre-commit.yaml:      - uses: actions/checkout@v5
.github/workflows/pre-commit.yaml:      - uses: j178/prek-action@v1
.github/workflows/sdk-adr.yaml:      - uses: actions/checkout@v4
.github/workflows/sdk-adr.yaml:        uses: astral-sh/setup-uv@v6
.github/workflows/sdk-adr.yaml:        uses: actions/setup-python@v5
.github/workflows/sdk-adr.yaml:        uses: actions/checkout@v4
.github/workflows/sdk-adr.yaml:        uses: actions/setup-go@v5
```
All are out of date except `j178/prek-action`.