### PR TITLE
Add ruff rules for Pylint, Refurb, and type hints

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.15.2
+  rev: v0.15.4
   hooks:
     # Run the linter.
     - id: ruff-check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,23 +59,20 @@ dev = [
 [tool.ruff]
 line-length = 99
 lint.select = [
-  # Annotations
-  "ANN",
-  # flake8-bugbear
-  "B",
-  "D",
-  # pycodestyle
-  "E",
-  # Pyflakes
-  "F",
-  # isort
-  "I",
-  # Ruff specific
-  "RUF",
-  # flake8-simplify
-  "SIM",
-  # pyupgrade
-  "UP",
+  "ANN",  # annotations
+  "B",    # flake8-bugbear
+  "D",    # pydocstyle
+  "DTZ",  # flake8-datetimez
+  "E",    # pycodestyle
+  "F",    # Pyflakes
+  "FURB", # refurb
+  "I",    # isort
+  "PL",   # Pylint
+  "PYI",  # flake8-pyi
+  "RUF",  # Ruff-specific rules
+  "SIM",  # flake8-simplify
+  "SLOT", # flake8-slots
+  "UP",   # pyupgrade
 ]
 lint.ignore = [
   "D100", # undocumented-public-module
@@ -90,5 +87,6 @@ lint.ignore = [
   "D415", # Duplicate of D400
   "E501",
 ]
-lint.per-file-ignores."examples/**/*.py" = [ "ANN" ]
+lint.per-file-ignores."examples/**/*.py" = [ "ANN", "DTZ005", "PLC0415" ]
 lint.fixable = [ "ALL" ]
+lint.pylint.allow-magic-value-types = [ "int", "str" ]

--- a/src/datastar_py/attributes.py
+++ b/src/datastar_py/attributes.py
@@ -127,13 +127,13 @@ class AttributeGenerator:
         :param expressions_: If True, the values of the signals will be evaluated as expressions
             rather than literals.
         """
-        signals = {**(signals_dict if signals_dict else {}), **signals}
+        signals = {**(signals_dict or {}), **signals}
         val = _js_object(signals) if expressions_ else json.dumps(signals)
         return SignalsAttr(value=val, alias=self._alias)
 
     def computed(self, computed_dict: Mapping | None = None, /, **computed: str) -> BaseAttr:
         """Create signals that are computed based on an expression."""
-        computed = {**(computed_dict if computed_dict else {}), **computed}
+        computed = {**(computed_dict or {}), **computed}
         first, *rest = (
             BaseAttr("computed", key=sig, value=expr, alias=self._alias)
             for sig, expr in computed.items()
@@ -152,7 +152,7 @@ class AttributeGenerator:
 
     def attr(self, attr_dict: Mapping | None = None, /, **attrs: str) -> BaseAttr:
         """Set the value of any HTML attributes to expressions, and keep them in sync."""
-        attrs = {**(attr_dict if attr_dict else {}), **attrs}
+        attrs = {**(attr_dict or {}), **attrs}
         return BaseAttr("attr", value=_js_object(attrs), alias=self._alias)
 
     def bind(self, signal_name: str) -> BaseAttr:
@@ -161,7 +161,7 @@ class AttributeGenerator:
 
     def class_(self, class_dict: Mapping | None = None, /, **classes: str) -> BaseAttr:
         """Add or removes classes to or from an element based on expressions."""
-        classes = {**(class_dict if class_dict else {}), **classes}
+        classes = {**(class_dict or {}), **classes}
         return BaseAttr("class", value=_js_object(classes), alias=self._alias)
 
     def init(self, expression: str) -> InitAttr:
@@ -216,7 +216,7 @@ class AttributeGenerator:
 
     def style(self, style_dict: Mapping | None = None, /, **styles: str) -> BaseAttr:
         """Set the value of inline CSS styles on an element based on an expression, and keeps them in sync."""
-        styles = {**(style_dict if style_dict else {}), **styles}
+        styles = {**(style_dict or {}), **styles}
         return BaseAttr("style", value=_js_object(styles), alias=self._alias)
 
     def text(self, expression: str) -> BaseAttr:
@@ -633,7 +633,7 @@ class OnIntersectAttr(BaseAttr, TimingMod, DelayMod, ViewtransitionMod):
 class OnIntervalAttr(BaseAttr, ViewtransitionMod):
     _attr = "on-interval"
 
-    def duration(self, duration: int | float | str, *, leading: bool = False) -> Self:
+    def duration(self, duration: float | str, *, leading: bool = False) -> Self:
         """Set the interval duration."""
         self._mods["duration"] = [str(duration)]
         if leading:

--- a/src/datastar_py/sse.py
+++ b/src/datastar_py/sse.py
@@ -5,7 +5,7 @@ from collections.abc import AsyncIterable, Iterable, Mapping
 from itertools import chain
 from typing import Literal, Protocol, TypeAlias, overload, runtime_checkable
 
-import datastar_py.consts as consts
+from datastar_py import consts
 from datastar_py.attributes import _escape
 
 SSE_HEADERS: dict[str, str] = {
@@ -28,7 +28,7 @@ class _HtmlProvider(Protocol):
 
 
 class DatastarEvent(str):
-    pass
+    __slots__ = ()
 
 
 # 0..N datastar events
@@ -83,7 +83,7 @@ class ServerSentEventGenerator:
         retry_duration: int | None = None,
     ) -> DatastarEvent: ...
     @classmethod
-    def patch_elements(
+    def patch_elements(  # noqa: PLR0913 too many arguments
         cls,
         elements: str | _HtmlProvider | None = None,
         selector: str | None = None,


### PR DESCRIPTION
Add `ruff` rules for datetimes, Pylint, refurb, slots, type hints, and ensure each comment matches the output of the command:
% `ruff linter`

---
Before:
% `ruff check --output-format=concise`
```
examples/django/ds/views.py:49:81: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/django/ds/views.py:60:45: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/django/ds/views.py:64:36: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/django/ds/views.py:109:81: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/django/ds/views.py:116:45: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/django/ds/views.py:120:36: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/django/manage.py:12:9: PLC0415 `import` should be at the top-level of a file
examples/fastapi/app.py:64:76: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/fastapi/app.py:70:41: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/fastapi/app.py:74:32: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/fasthtml/advanced.py:106:30: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/fasthtml/advanced.py:155:34: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/fasthtml/simple.py:38:30: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/fasthtml/simple.py:59:34: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/litestar/app.py:63:63: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/litestar/app.py:69:41: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/litestar/app.py:73:32: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/quart/app.py:67:45: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/quart/app.py:71:36: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/quart/app.py:80:63: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/sanic/app.py:65:68: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/sanic/app.py:89:41: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/sanic/app.py:111:45: DTZ005 `datetime.datetime.now()` called without a `tz` argument
examples/sanic/app.py:120:36: DTZ005 `datetime.datetime.now()` called without a `tz` argument
src/datastar_py/attributes.py:130:23: FURB110 [*] Replace ternary `if` expression with `or` operator
src/datastar_py/attributes.py:136:24: FURB110 [*] Replace ternary `if` expression with `or` operator
src/datastar_py/attributes.py:155:21: FURB110 [*] Replace ternary `if` expression with `or` operator
src/datastar_py/attributes.py:164:23: FURB110 [*] Replace ternary `if` expression with `or` operator
src/datastar_py/attributes.py:219:22: FURB110 [*] Replace ternary `if` expression with `or` operator
src/datastar_py/attributes.py:636:34: PYI041 [*] Use `float` instead of `int | float`
src/datastar_py/sanic.py:46:37: PLR2004 Magic value used in comparison, consider replacing `204` with a constant variable
src/datastar_py/sse.py:8:8: PLR0402 [*] Use `from datastar_py import consts` in lieu of alias
src/datastar_py/sse.py:30:7: SLOT000 Subclasses of `str` should define `__slots__`
src/datastar_py/sse.py:86:9: PLR0913 Too many arguments in function definition (7 > 5)
Found 34 errors.
[*] 7 fixable with the `--fix` option.
```