### PR TITLE
Fixed type hint for patch_signals

### DIFF
--- a/src/datastar_py/sse.py
+++ b/src/datastar_py/sse.py
@@ -136,7 +136,7 @@ class ServerSentEventGenerator:
     @classmethod
     def patch_signals(
         cls,
-        signals: dict[str, str] | str,
+        signals: dict[str, str | int | float | None] | str,
         event_id: str | None = None,
         only_if_missing: bool | None = None,
         retry_duration: int | None = None,

--- a/src/datastar_py/sse.py
+++ b/src/datastar_py/sse.py
@@ -136,7 +136,7 @@ class ServerSentEventGenerator:
     @classmethod
     def patch_signals(
         cls,
-        signals: dict[str, str | int | float | None] | str,
+        signals: dict[str, str | int | float | bool | None] | str,
         event_id: str | None = None,
         only_if_missing: bool | None = None,
         retry_duration: int | None = None,

--- a/src/datastar_py/sse.py
+++ b/src/datastar_py/sse.py
@@ -6,7 +6,7 @@ from itertools import chain
 from typing import Literal, Protocol, TypeAlias, overload, runtime_checkable
 
 import datastar_py.consts as consts
-from datastar_py.attributes import _escape
+from datastar_py.attributes import _escape, SignalValue
 
 SSE_HEADERS: dict[str, str] = {
     "Cache-Control": "no-cache",
@@ -136,7 +136,7 @@ class ServerSentEventGenerator:
     @classmethod
     def patch_signals(
         cls,
-        signals: dict[str, str | int | float | bool | None] | str,
+        signals: dict[str, SignalValue] | str,
         event_id: str | None = None,
         only_if_missing: bool | None = None,
         retry_duration: int | None = None,

--- a/src/datastar_py/sse.py
+++ b/src/datastar_py/sse.py
@@ -136,7 +136,7 @@ class ServerSentEventGenerator:
     @classmethod
     def patch_signals(
         cls,
-        signals: dict | str,
+        signals: dict[str, str] | str,
         event_id: str | None = None,
         only_if_missing: bool | None = None,
         retry_duration: int | None = None,


### PR DESCRIPTION
This is a small change to fix type hints for the `patch_signals` function.

I believe that, if the signals is a `dict`, then it needs to be json-encodable.

Since you call `json.dumps()` on line `154`, then it must be one of the _basic_ types.

From the `json.dumps` docs:

> Serialize obj to a JSON formatted str.
>
> If skipkeys is true then dict keys that are not basic types
>  (str, int, float, bool, None) will be skipped
>  instead of raising a TypeError.

Thanks for the awesome python package!