### PR TITLE
Fix: default to status 200 for non-empty DatastarResponse (Litestar)

### DIFF
--- a/src/datastar_py/litestar.py
+++ b/src/datastar_py/litestar.py
@@ -46,6 +46,7 @@ class DatastarResponse(Stream):
             status_code = status_code or 204
             content = tuple()
         else:
+            status_code = status_code or 200
             headers = {**self.default_headers, **(headers or {})}
         if isinstance(content, DatastarEvent):
             content = (content,)


### PR DESCRIPTION
## Problem

Litestar's `Stream` base class defaults to status `201` when no `status_code` is provided. Datastar's client-side fetch action (v1.0.0-RC.8) only processes SSE responses with status `200`:

```typescript
// fetch.ts line 561
if (status !== 200) { dispose(); resolve(); return; }
```

This means every `DatastarResponse` with content silently fails — the browser receives the SSE stream, but Datastar discards it without processing any `patch-elements` or `patch-signals` events.

## Fix

One line: default to `200` when content is present and no explicit status code is given. Same pattern already used for the empty-content `204` case.

```python
else:
    status_code = status_code or 200  # added
    headers = {**self.default_headers, **(headers or {})}
```

## Impact

Without this fix, every Litestar app using `DatastarResponse` must either:
- Pass `status_code=200` on every call
- Subclass `DatastarResponse` to override the default

Both are non-obvious workarounds for what should be a sensible default.