### PR TITLE
Remove datastar_response decorator for FastAPI and document replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ async def my_route(request):
         await asyncio.sleep(1)
 ```
 
+> [!NOTE]
+> The `datastar_response` decorator is not needed, (and not provided by the fastapi module,) for FastAPI. Instead, `response_class=DatastarResponse` should be specified in the route decorator to achieve the same result.   
+
 ## Signal Helpers
 The current state of the datastar signals is included by default in every
 datastar request. A helper is included to load those signals for each

--- a/examples/fastapi/app.py
+++ b/examples/fastapi/app.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 import uvicorn
 from fastapi import FastAPI
-from fastapi.responses import HTMLResponse, StreamingResponse
+from fastapi.responses import HTMLResponse
 
 from datastar_py.fastapi import (
     DatastarResponse,
@@ -21,7 +21,7 @@ from datastar_py.fastapi import (
     ServerSentEventGenerator,
 )
 
-app = FastAPI()
+app = FastAPI(debug=True)
 
 
 HTML = """\
@@ -64,7 +64,10 @@ async def read_root():
     return HTMLResponse(HTML.replace("CURRENT_TIME", f"{datetime.isoformat(datetime.now())}"))
 
 
-async def time_updates():
+@app.get("/updates", response_class=DatastarResponse)
+async def time_updates(signals: ReadSignals):
+    # ReadSignals is a dependency that automatically loads the signals from the request
+    print(signals)
     while True:
         yield ServerSentEventGenerator.patch_elements(
             f"""<span id="currentTime">{datetime.now().isoformat()}"""
@@ -74,13 +77,6 @@ async def time_updates():
             {"currentTime": f"{datetime.now().isoformat()}"}
         )
         await asyncio.sleep(1)
-
-
-@app.get("/updates", response_class=StreamingResponse)
-async def updates(signals: ReadSignals):
-    # ReadSignals is a dependency that automatically loads the signals from the request
-    print(signals)
-    return DatastarResponse(time_updates())
 
 
 if __name__ == "__main__":

--- a/src/datastar_py/fastapi.py
+++ b/src/datastar_py/fastapi.py
@@ -3,14 +3,13 @@ from typing import Annotated, Any
 from fastapi import Depends
 
 from .sse import SSE_HEADERS, ServerSentEventGenerator
-from .starlette import DatastarResponse, datastar_response, read_signals
+from .starlette import DatastarResponse, read_signals
 
 __all__ = [
     "SSE_HEADERS",
     "DatastarResponse",
     "ReadSignals",
     "ServerSentEventGenerator",
-    "datastar_response",
     "read_signals",
 ]
 


### PR DESCRIPTION
The `datastar_response` decorator stopped working in recent versions of FastAPI. I'm not sure how to best implement it anymore due to the way FastAPI is inspecting the route function to support the new streaming generator syntax. However... the changes in FastAPI that broke the decorator also enable the same functionality by just declaring `response_class=DatastarResponese` on the route decorator, so I think it's probably okay to just drop `datastar_response` from that module.

I guess the open issue is just if people are stuck on older versions of FastAPI. Are there such people using the SDK that will be negatively impacted by this?