### PR TITLE
Sanic typing fixes

### DIFF
--- a/src/datastar_py/sanic.py
+++ b/src/datastar_py/sanic.py
@@ -96,5 +96,5 @@ def datastar_response(
     return wrapper
 
 
-async def read_signals(request: Request) -> dict[str, Any] | None:
+async def read_signals(request: Request[Any, Any]) -> dict[str, Any] | None:
     return _read_signals(request.method, request.headers, request.args, request.body)

--- a/src/datastar_py/sanic.py
+++ b/src/datastar_py/sanic.py
@@ -40,14 +40,14 @@ class DatastarResponse(HTTPResponse):
 
     async def send(
         self,
-        event: DatastarEvent | None = None,
+        data: DatastarEvent | None = None,
         end_stream: bool | None = None,
     ) -> None:
-        if event and self.status == 204:
+        if data and self.status == 204:
             # When the response is created with no content, it's set to a 204 by default
             # if we end up streaming to it, change the status code to 200 before sending.
             self.status = 200
-        await super().send(event, end_stream=end_stream)
+        await super().send(data, end_stream=end_stream)
 
 
 async def datastar_respond(


### PR DESCRIPTION
- Fixes Sanic's `read_signals` helper so it doesn't complain if you are using a customized sanic Request class.
- Fixes Sanic's `DatastarResponse` class so that type checkers don't complain about the argument compatibility with the superclass method.