### PR TITLE
Add Bottle adapter, example, and tests

### DIFF
--- a/examples/bottle/app.py
+++ b/examples/bottle/app.py
@@ -1,0 +1,63 @@
+import time
+from datetime import datetime
+from bottle import route, run, template
+from datastar_py.bottle import ServerSentEventGenerator, datastar_response
+
+
+html = """\
+    <!DOCTYPE html>
+    <html lang="en">
+        <head>
+            <title>DATASTAR on Bottle (WSGI)</title>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+            <script type="module" src="https://cdn.jsdelivr.net/gh/starfederation/datastar@v1.0.2/bundles/datastar.js"></script>
+            <style>
+            html, body { height: 100%; width: 100%; }
+            body { background-image: linear-gradient(to right bottom, oklch(0.424958 0.052808 253.972015), oklch(0.189627 0.038744 264.832977)); }
+            .container { display: grid; place-content: center; }
+            .time { padding: 2rem; border-radius: 8px; margin-top: 3rem; font-family: monospace, sans-serif; background-color: oklch(0.916374 0.034554 90.5157); color: oklch(0.265104 0.006243 0.522862 / 0.6); font-weight: 600; }
+            </style>
+        </head>
+        <body
+            data-signals="{currentTime: 'CURRENT_TIME'}"
+        >
+        <div class="container">
+            <div
+            class="time"
+            data-init="@get('/updates/')"
+            >
+            Current time from element: <span id="currentTime">CURRENT_TIME</span>
+            </div>
+            <div
+            class="time"
+            >
+            Current time from signal: <span data-text="$currentTime">CURRENT_TIME</span>
+            </div>
+        </div>
+        </body>
+    </html>
+"""
+
+
+@route("/")
+def home():
+    return template(html.replace("CURRENT_TIME", f"{datetime.isoformat(datetime.now())}"))
+
+
+@route("/updates/")
+@datastar_response
+def updates():
+    while True:
+        yield ServerSentEventGenerator.patch_elements(
+            f"""<span id="currentTime">{datetime.now().isoformat()}"""
+        )
+
+        time.sleep(0.5)
+
+        yield ServerSentEventGenerator.patch_signals({"currentTime": datetime.now().isoformat()})
+
+        time.sleep(0.5)
+
+
+if __name__ == "__main__":
+    run(host="localhost", port=8080)

--- a/src/datastar_py/bottle.py
+++ b/src/datastar_py/bottle.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from functools import wraps
+from typing import Any, ParamSpec
+
+from bottle import HTTPResponse
+from bottle import request as _request
+
+from . import _read_signals
+from .sse import (
+    SSE_HEADERS,
+    DatastarEvent,
+    DatastarEvents,
+    ServerSentEventGenerator,
+)
+
+__all__ = [
+    "SSE_HEADERS",
+    "DatastarResponse",
+    "ServerSentEventGenerator",
+    "datastar_response",
+    "read_signals",
+]
+
+
+class DatastarResponse(HTTPResponse):
+    """Respond with 0..N `DatastarEvent`s.
+
+    Bottle natively streams iterable response bodies, so generators are
+    passed through unchanged and consumed as they produce events.
+    """
+
+    default_headers: dict[str, str] = SSE_HEADERS.copy()
+
+    def __init__(
+        self,
+        content: DatastarEvents = None,
+        *,
+        status: int | None = None,
+        headers: Mapping[str, str] | None = None,
+    ) -> None:
+        if content is None:
+            status = status or 204
+            content = ""
+            headers = headers or {}
+        else:
+            status = status or 200
+            headers = {**self.default_headers, **(headers or {})}
+
+        if isinstance(content, DatastarEvent):
+            content = (content,)
+
+        super().__init__(
+            body=content,
+            status=status,
+            headers=headers,
+        )
+
+
+P = ParamSpec("P")
+
+
+def datastar_response(
+    func: Callable[P, DatastarEvents],
+) -> Callable[P, DatastarResponse]:
+    """Wrap a route callback's result in a `DatastarResponse`.
+
+    The wrapped function may return a single event, an iterable of events,
+    or a generator yielding events.
+    """
+
+    @wraps(func)
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> DatastarResponse:
+        return DatastarResponse(func(*args, **kwargs))
+
+    wrapper.__annotations__["return"] = DatastarResponse
+    return wrapper
+
+
+def read_signals() -> dict[str, Any] | None:
+    body = _request.body
+    if hasattr(body, "read"):
+        body = body.read()
+
+    return _read_signals(
+        _request.method,
+        _request.headers,
+        _request.query,
+        body,
+    )

--- a/tests/test_decorator_matrix.py
+++ b/tests/test_decorator_matrix.py
@@ -18,6 +18,7 @@ FRAMEWORKS = [
     ("fastapi", "datastar_py.fastapi", "body_iterator"),
     ("litestar", "datastar_py.litestar", "iterator"),
     ("django", "datastar_py.django", None),
+    ("bottle", "datastar_py.bottle", None),
     # Quart and Sanic need full request contexts; covered elsewhere
     ("quart", "datastar_py.quart", None),
     ("sanic", "datastar_py.sanic", None),
@@ -65,6 +66,10 @@ async def test_datastar_response_matrix(
     """Ensure decorator works for sync/async and generator/non-generator functions."""
     if framework_name in {"quart", "sanic"}:
         pytest.skip(f"{framework_name} decorator requires full request context to exercise")
+
+    if framework_name == "bottle" and variant in {"async_value", "async_generator"}:
+        pytest.skip("Bottle is synchronous and does not support async route callbacks")
+
     if framework_name == "django":
         from django.conf import settings
 


### PR DESCRIPTION
Adds Bottle framework support to the Python SDK.


Bottle is synchronous/WSGI-only, but it natively supports iterable and generator response body, streaming each yielded value to the client. This makes it a straightforward fit for Datastar's SSE generators without requiring any async-specific handling.

Also included is a Bottle example and matrix tests covering the supported synchronous callable types.