### PR TITLE
fix: typo in viewtransition mod

### DIFF
--- a/src/datastar_py/attributes.py
+++ b/src/datastar_py/attributes.py
@@ -408,7 +408,7 @@ class ViewtransitionMod:
     @property
     def viewtransition(self: Self) -> Self:
         """Wrap the expression in document.startViewTransition()."""
-        self._mods["view-transition"] = []
+        self._mods["viewtransition"] = []
         return self
 
 


### PR DESCRIPTION
From reference: https://data-star.dev/reference/attributes#data-init

<img width="960" height="475" alt="image" src="https://github.com/user-attachments/assets/3d524881-3a34-4b80-9d1b-aac0366e1b36" />
