### PR TITLE
feat: Add expression serializer for AttributeGenerator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: test lint
 
 test:
-	uv run --dev pytest
+	@trap 'rm -f uv.lock' EXIT; uv run --with pytest pytest
 
 lint:
 	uv run --dev pre-commit run --all-files

--- a/src/datastar_py/attributes.py
+++ b/src/datastar_py/attributes.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import collections.abc
+import dataclasses
 import json
 import re
 from collections.abc import Iterable, Iterator, Mapping
@@ -101,8 +103,78 @@ JSEvent = Literal[
 
 
 SignalValue: TypeAlias = (
-    str | int | float | bool | dict[str, "SignalValue"] | list["SignalValue"] | None
+    str
+    | int
+    | float
+    | bool
+    | dict[str, "SignalValue"]
+    | list["SignalValue"]
+    | tuple["SignalValue", ...]
+    | None
 )
+
+
+@dataclasses.dataclass(frozen=True)
+class JSExpression:
+    """JavaScript expression."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        """Reject empty or non-string expression source."""
+        _require_nonblank_string("JSExpression.value", self.value)
+
+
+def _require_nonblank_string(name: str, value: object) -> None:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value.strip():
+        raise ValueError(f"{name} must be non-empty")
+
+
+def javascript(value: object) -> str:
+    """Serialize data recursively."""
+    if isinstance(value, JSExpression):
+        return f"({value.value})"
+    if isinstance(value, collections.abc.Mapping):
+        if any(not isinstance(key, str) for key in value):
+            raise TypeError("JavaScript object keys must be strings")
+        # TODO: Revisit when `__proto__` should be special cased
+        return (
+            "{"
+            + ", ".join(f"{javascript(key)}: {javascript(item)}" for key, item in value.items())
+            + "}"
+        )
+    if isinstance(value, list | tuple):
+        return "[" + ", ".join(javascript(item) for item in value) + "]"
+    serialized = json.dumps(value, allow_nan=False)
+    # NOTE: Escape `@` in action-like syntax
+    # Browser decodes \u0040 back to `@` symbol.
+    return re.sub(
+        r"""
+        @                   # Match the action marker.
+        (?=                 # positive lookahead for an action name followed
+                            # by an opening parenthesis. e.g. `@foo(` or `@QUX(`
+            [A-Za-z_$]      # First name character: ASCII letter, underscore, or dollar sign.
+            [A-Za-z0-9_$]*  # Zero or more name characters, also allowing digits.
+            \(              # Opening parenthesis immediately after the name.
+        )
+        """,
+        r"\\u0040",
+        serialized,
+        flags=re.VERBOSE,
+    )
+
+
+def _as_javascript_expressions(value: object) -> object:
+    """Wrap strings in a nested javascript expressions."""
+    if isinstance(value, collections.abc.Mapping):
+        return {key: _as_javascript_expressions(item) for key, item in value.items()}
+    if isinstance(value, list | tuple):
+        return [_as_javascript_expressions(item) for item in value]
+    if isinstance(value, str):
+        return JSExpression(value)
+    return value
 
 
 class AttributeGenerator:
@@ -128,7 +200,7 @@ class AttributeGenerator:
             rather than literals.
         """
         signals = {**(signals_dict or {}), **signals}
-        val = _js_object(signals) if expressions_ else json.dumps(signals)
+        val = javascript(_as_javascript_expressions(signals) if expressions_ else signals)
         return SignalsAttr(value=val, alias=self._alias)
 
     def computed(self, computed_dict: Mapping | None = None, /, **computed: str) -> BaseAttr:
@@ -153,7 +225,11 @@ class AttributeGenerator:
     def attr(self, attr_dict: Mapping | None = None, /, **attrs: str) -> BaseAttr:
         """Set the value of any HTML attributes to expressions, and keep them in sync."""
         attrs = {**(attr_dict or {}), **attrs}
-        return BaseAttr("attr", value=_js_object(attrs), alias=self._alias)
+        return BaseAttr(
+            "attr",
+            value=javascript(_as_javascript_expressions(attrs)),
+            alias=self._alias,
+        )
 
     def bind(self, signal_name: str) -> BaseAttr:
         """Set up two-way data binding between a signal and an element's value."""
@@ -162,7 +238,11 @@ class AttributeGenerator:
     def class_(self, class_dict: Mapping | None = None, /, **classes: str) -> BaseAttr:
         """Add or removes classes to or from an element based on expressions."""
         classes = {**(class_dict or {}), **classes}
-        return BaseAttr("class", value=_js_object(classes), alias=self._alias)
+        return BaseAttr(
+            "class",
+            value=javascript(_as_javascript_expressions(classes)),
+            alias=self._alias,
+        )
 
     def init(self, expression: str) -> InitAttr:
         """Execute an expression when the element is loaded into the DOM."""
@@ -217,7 +297,11 @@ class AttributeGenerator:
     def style(self, style_dict: Mapping | None = None, /, **styles: str) -> BaseAttr:
         """Set the value of inline CSS styles on an element based on an expression, and keeps them in sync."""
         styles = {**(style_dict or {}), **styles}
-        return BaseAttr("style", value=_js_object(styles), alias=self._alias)
+        return BaseAttr(
+            "style",
+            value=javascript(_as_javascript_expressions(styles)),
+            alias=self._alias,
+        )
 
     def text(self, expression: str) -> BaseAttr:
         """Bind the text content of an element to an expression."""
@@ -726,18 +810,6 @@ def _filter_dict(include: str | None = None, exclude: str | None = None) -> dict
     if exclude:
         filter_dict["exclude"] = exclude
     return filter_dict
-
-
-def _js_object(obj: dict) -> str:
-    """Create a JS object where the values are expressions rather than strings."""
-    return (
-        "{"
-        + ", ".join(
-            f"{json.dumps(k)}: {_js_object(v) if isinstance(v, dict) else v}"
-            for k, v in obj.items()
-        )
-        + "}"
-    )
 
 
 attribute_generator = AttributeGenerator()

--- a/tests/test_attributes.py
+++ b/tests/test_attributes.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import json
+import math
+import unittest
+
+from datastar_py.attributes import JSExpression, javascript
+from datastar_py.attributes import attribute_generator as ds
+
+
+class AttributeJavascriptTests(unittest.TestCase):
+    def test_expression_apis_parenthesize_ambiguous_values(self) -> None:
+        cases = (
+            (
+                ds.attr(title="first, second"),
+                {"data-attr": '{"title": (first, second)}'},
+            ),
+            (
+                ds.class_({"active": "first, second"}),
+                {"data-class": '{"active": (first, second)}'},
+            ),
+            (
+                ds.style(width="first, second"),
+                {"data-style": '{"width": (first, second)}'},
+            ),
+            (
+                ds.signals(
+                    items1=["first", "second"],
+                    items2=["first, second"],
+                    items3="first, second",
+                ),
+                {
+                    "data-signals": (
+                        '{"items1": ["first", "second"], "items2": ["first, second"], "items3": "first, second"}'
+                    )
+                },
+            ),
+            (
+                ds.signals(
+                    items1=["first", "second"],
+                    items2=["first, second"],
+                    items3="first, second",
+                    expressions_=True,
+                ),
+                {
+                    "data-signals": (
+                        '{"items1": [(first), (second)], "items2": [(first, second)], "items3": (first, second)}'
+                    )
+                },
+            ),
+            (
+                ds.signals(
+                    {
+                        "items1": ["first", "second"],
+                        "items2": ["first, second"],
+                        "items3": "first, second",
+                    },
+                ),
+                {
+                    "data-signals": (
+                        '{"items1": ["first", "second"], "items2": ["first, second"], "items3": "first, second"}'
+                    )
+                },
+            ),
+            (
+                ds.signals(
+                    {
+                        "items1": ["first", "second"],
+                        "items2": ["first, second"],
+                        "items3": "first, second",
+                        "expressions_": False,
+                    },
+                    expressions_=True,
+                ),
+                {
+                    "data-signals": (
+                        '{"items1": [(first), (second)], "items2": [(first, second)], "items3": (first, second), "expressions_": false}'
+                    )
+                },
+            ),
+            (
+                ds.signals(
+                    {
+                        "items1": ["first", "second"],
+                        "items2": ["first, second"],
+                        "items3": "first, second",
+                    },
+                    expressions_=True,
+                ),
+                {
+                    "data-signals": (
+                        '{"items1": [(first), (second)], "items2": [(first, second)], "items3": (first, second)}'
+                    )
+                },
+            ),
+            (
+                ds.signals(
+                    {
+                        "items1": ("first", "second"),
+                        "items2": ("first, second",),
+                        "items3": "first, second",
+                    },
+                ),
+                {
+                    "data-signals": (
+                        '{"items1": ["first", "second"], "items2": ["first, second"], "items3": "first, second"}'
+                    )
+                },
+            ),
+            (
+                ds.signals(
+                    {
+                        "items1": ("first", "second"),
+                        "items2": ("first, second",),
+                        "items3": "first, second",
+                    },
+                    expressions_=True,
+                ),
+                {
+                    "data-signals": (
+                        '{"items1": [(first), (second)], "items2": [(first, second)], "items3": (first, second)}'
+                    )
+                },
+            ),
+            (
+                ds.signals(
+                    {
+                        "answer1": '{"value": 42}',
+                        "answer2": {"value": 42},
+                    },
+                    expressions_=True,
+                ),
+                {"data-signals": ('{"answer1": ({"value": 42}), "answer2": {"value": 42}}')},
+            ),
+            (
+                ds.signals(
+                    {
+                        "answer1": '{"value": 42}',
+                        "answer2": {"value": 42},
+                    },
+                ),
+                {"data-signals": ('{"answer1": "{\\"value\\": 42}", "answer2": {"value": 42}}')},
+            ),
+        )
+
+        for attribute, expected in cases:
+            with self.subTest(attribute=next(iter(attribute))):
+                self.assertEqual(dict(attribute), expected)
+
+    def test_expression_apis_wrap_values_explicitly(self) -> None:
+        cases = (
+            (
+                ds.attr(title='"hello"', hidden="$closed"),
+                {"data-attr": '{"title": ("hello"), "hidden": ($closed)}'},
+            ),
+            (
+                ds.class_({"active item": "$selected", "plain": "true"}),
+                {"data-class": '{"active item": ($selected), "plain": (true)}'},
+            ),
+            (
+                ds.style(width="$width + 'px'"),
+                {"data-style": "{\"width\": ($width + 'px')}"},
+            ),
+            (
+                ds.signals({"form": {"count": "1 + 1"}}),
+                {"data-signals": '{"form": {"count": "1 + 1"}}'},
+            ),
+            (
+                ds.signals({"form": {"count": "1 + 1"}}, expressions_=True),
+                {"data-signals": '{"form": {"count": (1 + 1)}}'},
+            ),
+        )
+
+        for attribute, expected in cases:
+            with self.subTest(attribute=next(iter(attribute))):
+                self.assertEqual(dict(attribute), expected)
+
+    def test_expression_signals_recurse_through_nested_lists(self) -> None:
+        self.assertEqual(
+            dict(
+                ds.signals(
+                    {
+                        "form": {
+                            "total": "2 * 3",
+                            "items": ["$first", "$second"],
+                            "groups": [["$third"]],
+                        }
+                    },
+                    expressions_=True,
+                )
+            ),
+            {
+                "data-signals": (
+                    '{"form": {"total": (2 * 3), "items": [($first), ($second)], '
+                    '"groups": [[($third)]]}}'
+                )
+            },
+        )
+
+    def test_literal_signals_remain_data_and_escape_action_tokens(self) -> None:
+        signals = {
+            "signal_example": "$otherSignal",
+            "action_example": '@post("/sse")',
+            "email_example": "person@example.com",
+            "expression_example": "1 + 1",
+            "quoted_example": 'a "quoted" value',
+        }
+
+        rendered = dict(ds.signals(signals))["data-signals"]
+        assert isinstance(rendered, str)
+
+        self.assertEqual(
+            rendered,
+            "".join(
+                [
+                    '{"signal_example": "$otherSignal", ',
+                    '"action_example": "\\u0040post(\\"/sse\\")", ',
+                    '"email_example": "person@example.com", ',
+                    '"expression_example": "1 + 1", ',
+                    '"quoted_example": "a \\"quoted\\" value"}',
+                ]
+            ),
+        )
+        self.assertEqual(json.loads(rendered), signals)
+
+    def test_mapping_values_serialize_recursively(self) -> None:
+        value = {
+            "literal": "text",
+            "nested": {
+                # These Python spellings differ from JavaScript
+                # This test can catch accidental fallbacks to str()
+                # instead of JSON serialization.
+                "items": [True, False, None, 3],
+                "expression": JSExpression("1 + 1"),
+            },
+        }
+
+        self.assertEqual(
+            javascript(value),
+            '{"literal": "text", "nested": {"items": [true, false, null, 3], "expression": (1 + 1)}}',
+        )
+
+    def test_mapping_keys_are_strings_and_escaped_as_data(self) -> None:
+        with self.assertRaisesRegex(TypeError, "object keys must be strings"):
+            javascript({1: "value"})
+
+        self.assertEqual(
+            javascript(
+                {
+                    'quote"\\snow雪': "value",
+                    '@post("key")': "action-looking key",
+                }
+            ),
+            '{"quote\\"\\\\snow\\u96ea": "value", "\\u0040post(\\"key\\")": "action-looking key"}',
+        )
+
+    def test_non_finite_signal_values_are_rejected_in_both_modes(self) -> None:
+        for expressions in (False, True):
+            for value in (math.nan, math.inf, -math.inf):
+                with (
+                    self.subTest(expressions=expressions, value=value),
+                    self.assertRaises(ValueError),
+                ):
+                    ds.signals({"value": value}, expressions_=expressions)

--- a/tests/test_django_decorator_typing.py
+++ b/tests/test_django_decorator_typing.py
@@ -35,7 +35,10 @@ def test_django_datastar_response_mypy_overloads() -> None:
         'Revealed type is "def (request: django.http.request.HttpRequest) '
         '-> datastar_py.django.DatastarResponse"'
     ) in output
-    assert output.count(
-        'Revealed type is "def (request: django.http.request.HttpRequest) '
-        '-> typing.Coroutine[Any, Any, datastar_py.django.DatastarResponse]"'
-    ) == 2
+    assert (
+        output.count(
+            'Revealed type is "def (request: django.http.request.HttpRequest) '
+            '-> typing.Coroutine[Any, Any, datastar_py.django.DatastarResponse]"'
+        )
+        == 2
+    )


### PR DESCRIPTION
This PR extracts the expression serializer parts of the draft PR from https://github.com/starfederation/datastar-python/pull/13

Instead of the existing `_js_object`, in this PR a recursive serializer is used. Specifically, the previous `_js_object` helper recursively handled dictionaries, but inserted other values using their Python string representation. 

This PR introduces a `javascript()` helper which:

- recursively handles strings inside lists and tuples as expressions;
- serializes `True`, `False`, and `None` as JavaScript;

For example, if a user were to write this code:

```python
import htpy as h
from datastar_py.attributes import attribute_generator as ds

viewport = h.div(
    ds.signals(
        {
            "viewport": {
                "dimensions": ["window.innerWidth", "window.innerHeight"],
                "position": ("window.scrollX", "window.scrollY"),
                "fullscreen": False,
            }
        },
        expressions_=True,
    )
)
```

Before this PR:

```html
<div data-signals='{
    "viewport": {"dimensions": ["window.innerWidth", "window.innerHeight"], 
    "position": ("window.scrollX", "window.scrollY")}
    "fullscreen": False,
}'></div>
```

After this PR:

```html
<div data-signals='{
    "viewport": {"dimensions": [(window.innerWidth), (window.innerHeight)], 
    "position": [(window.scrollX), (window.scrollY)]}
    "fullscreen": false,
}'></div>
```

In this example, previously the signal would be `["window.innerWidth", "window.innerHeight"]` which would be the string text but with this PR the signals will be `[window.innerWidth, window.innerHeight]`, i.e. the value at the time. 